### PR TITLE
Update ubuntu to 21.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:21.04
 
 LABEL maintainer="julian.fischer@anynines.com"
 LABEL description="Facerecognition using (Darnket) Yolo Weights."


### PR DESCRIPTION
Installing opencv no longer worked with the old version of pip installed under 18.04